### PR TITLE
:loud_sound: Make container's journal entry comments predictable

### DIFF
--- a/flows.json
+++ b/flows.json
@@ -4414,7 +4414,7 @@
                 "t": "set",
                 "p": "journal",
                 "pt": "msg",
-                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"success\",\t   \"comments\": \"operation \" & msg.input.data.operation & \" ok \"\t}",
+                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"success\",\t   \"comments\": \"operation \" & msg.input.data.operation & \": ok\"\t}",
                 "tot": "jsonata"
             }
         ],
@@ -4572,7 +4572,7 @@
                 "t": "set",
                 "p": "journal",
                 "pt": "msg",
-                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"info\",\t   \"comments\": $string(msg.input.data.operation & \"-ing\")\t}",
+                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"info\",\t   \"comments\": \"operating \" & msg.input.data.operation & \": pending\"\t}",
                 "tot": "jsonata"
             }
         ],
@@ -4617,7 +4617,7 @@
                 "t": "set",
                 "p": "journal",
                 "pt": "msg",
-                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"warning\",\t   \"comments\": $string(msg.input.data.operation & \" | failed\")\t}",
+                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"warning\",\t   \"comments\": \"operation \" & msg.input.data.operation & \": failed\"\t}",
                 "tot": "jsonata"
             }
         ],
@@ -4682,7 +4682,7 @@
                 "t": "set",
                 "p": "journal",
                 "pt": "msg",
-                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"danger\",\t   \"comments\":  $string(msg.payload)\t}",
+                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"danger\",\t   \"comments\":  \"operation \" & msg.input.data.operation & \": error => \" & $string(msg.payload)\t}",
                 "tot": "jsonata"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netbox-docker-agent",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Saashup agent for netbox manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Decision Record

In order to better filter journal entries on a container, we want to make the format of the comments more predictable:

| Kind | Comment pattern |
| --- | --- |
| `info` | `operation $op: pending` |
| `success` | `operation $op: ok` |
| `warning` | `operation $op: failed` |
| `danger` | `operation $op: error => $err` |

For example:
 - `operation start: ok`
 - `operation create: error => {some big json}`

## Changes

 - [x] :loud_sound: Update container's journal entry comments
 - [x] :bookmark: v0.22.0