### PR TITLE
:sparkles: Force pull image

### DIFF
--- a/flows.json
+++ b/flows.json
@@ -2827,13 +2827,11 @@
         "type": "switch",
         "z": "3ea1a4b04d852f38",
         "name": "should we pull?",
-        "property": "payload.data.size",
-        "propertyType": "msg",
+        "property": "(\t    msg.payload.data.size <= 0\t    or msg.payload.data.force = true\t)\t",
+        "propertyType": "jsonata",
         "rules": [
             {
-                "t": "lte",
-                "v": "0",
-                "vt": "num"
+                "t": "true"
             }
         ],
         "checkall": "true",

--- a/flows.json
+++ b/flows.json
@@ -2853,8 +2853,8 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1380,
-        "y": 580,
+        "x": 2370,
+        "y": 520,
         "wires": [
             [
                 "d375e2981f9fa4fb"
@@ -2873,8 +2873,8 @@
         "winHide": false,
         "oldrc": false,
         "name": "docker api request: inspect image",
-        "x": 1120,
-        "y": 580,
+        "x": 2160,
+        "y": 520,
         "wires": [
             [
                 "2eb2de8f9ca00a2b"
@@ -2964,8 +2964,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1580,
-        "y": 580,
+        "x": 2570,
+        "y": 520,
         "wires": [
             [
                 "231e0a10bb5c0cac",
@@ -2989,8 +2989,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 1870,
-        "y": 620,
+        "x": 2850,
+        "y": 520,
         "wires": [
             [
                 "829323373ce00e9e"
@@ -3521,8 +3521,8 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 2045,
-        "y": 620,
+        "x": 3025,
+        "y": 520,
         "wires": []
     },
     {
@@ -3530,8 +3530,8 @@
         "type": "subflow:0455d311f0e53c09",
         "z": "3ea1a4b04d852f38",
         "name": "",
-        "x": 890,
-        "y": 460,
+        "x": 1070,
+        "y": 540,
         "wires": []
     },
     {
@@ -3539,8 +3539,8 @@
         "type": "subflow:0455d311f0e53c09",
         "z": "3ea1a4b04d852f38",
         "name": "",
-        "x": 2150,
-        "y": 580,
+        "x": 2790,
+        "y": 480,
         "wires": []
     },
     {
@@ -3591,11 +3591,11 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1890,
-        "y": 480,
+        "x": 1830,
+        "y": 460,
         "wires": [
             [
-                "042f9d4dafa3cf3d"
+                "4d5d170a3b67d702"
             ]
         ]
     },
@@ -3673,6 +3673,15 @@
         "info": "",
         "x": 580,
         "y": 100,
+        "wires": []
+    },
+    {
+        "id": "4d5d170a3b67d702",
+        "type": "subflow:0455d311f0e53c09",
+        "z": "3ea1a4b04d852f38",
+        "name": "",
+        "x": 2010,
+        "y": 460,
         "wires": []
     },
     {

--- a/flows.json
+++ b/flows.json
@@ -2625,7 +2625,7 @@
         "method": "post",
         "upload": false,
         "swaggerDoc": "",
-        "x": 200,
+        "x": 130,
         "y": 200,
         "wires": [
             [
@@ -2638,7 +2638,7 @@
         "id": "5db8c0db8473ea8e",
         "type": "switch",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "route by :type",
         "property": "req.params.type",
         "propertyType": "msg",
         "rules": [
@@ -2671,7 +2671,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 5,
-        "x": 410,
+        "x": 360,
         "y": 200,
         "wires": [
             [
@@ -2744,9 +2744,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "images",
-        "x": 1000,
-        "y": 480,
+        "name": "docker api request: pull image",
+        "x": 1110,
+        "y": 580,
         "wires": [
             [
                 "5c79a22a8f9ad79f"
@@ -2762,7 +2762,7 @@
         "name": "",
         "statusCode": "202",
         "headers": {},
-        "x": 200,
+        "x": 130,
         "y": 260,
         "wires": []
     },
@@ -2770,7 +2770,7 @@
         "id": "7d0f6463ecfeeb50",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare docker api request",
         "rules": [
             {
                 "t": "set",
@@ -2813,8 +2813,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 800,
-        "y": 480,
+        "x": 820,
+        "y": 580,
         "wires": [
             [
                 "b49c4832fc35827a",
@@ -2826,7 +2826,7 @@
         "id": "dfd9416e4f31ef88",
         "type": "switch",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "should we pull?",
         "property": "payload.data.size",
         "propertyType": "msg",
         "rules": [
@@ -2839,8 +2839,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 610,
-        "y": 480,
+        "x": 580,
+        "y": 580,
         "wires": [
             [
                 "7d0f6463ecfeeb50"
@@ -2855,8 +2855,8 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1180,
-        "y": 560,
+        "x": 1360,
+        "y": 660,
         "wires": [
             [
                 "d375e2981f9fa4fb"
@@ -2874,9 +2874,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "images",
-        "x": 1010,
-        "y": 560,
+        "name": "docker api request: inspect image",
+        "x": 1100,
+        "y": 660,
         "wires": [
             [
                 "2eb2de8f9ca00a2b"
@@ -2889,7 +2889,7 @@
         "id": "3a845c367b89a50e",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare docker api request",
         "rules": [
             {
                 "t": "set",
@@ -2904,8 +2904,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1640,
-        "y": 500,
+        "x": 1840,
+        "y": 600,
         "wires": [
             [
                 "cc3c1cea0eb84ca0"
@@ -2916,7 +2916,7 @@
         "id": "d375e2981f9fa4fb",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare netbox request",
         "rules": [
             {
                 "t": "set",
@@ -2966,8 +2966,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1370,
-        "y": 560,
+        "x": 1560,
+        "y": 660,
         "wires": [
             [
                 "231e0a10bb5c0cac",
@@ -2979,7 +2979,7 @@
         "id": "231e0a10bb5c0cac",
         "type": "http request",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "netbox request: update image",
         "method": "use",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -2991,8 +2991,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 1580,
-        "y": 600,
+        "x": 1850,
+        "y": 700,
         "wires": [
             [
                 "829323373ce00e9e"
@@ -3550,8 +3550,8 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 1735,
-        "y": 600,
+        "x": 2025,
+        "y": 700,
         "wires": []
     },
     {
@@ -3559,8 +3559,8 @@
         "type": "subflow:0455d311f0e53c09",
         "z": "3ea1a4b04d852f38",
         "name": "",
-        "x": 810,
-        "y": 440,
+        "x": 870,
+        "y": 540,
         "wires": []
     },
     {
@@ -3568,15 +3568,15 @@
         "type": "subflow:0455d311f0e53c09",
         "z": "3ea1a4b04d852f38",
         "name": "",
-        "x": 1900,
-        "y": 560,
+        "x": 2130,
+        "y": 660,
         "wires": []
     },
     {
         "id": "84d8b152e92556ef",
         "type": "switch",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "did it work?",
         "property": "payload",
         "propertyType": "msg",
         "rules": [
@@ -3590,8 +3590,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1420,
-        "y": 480,
+        "x": 1610,
+        "y": 580,
         "wires": [
             [
                 "dce108611cd0c5ba"
@@ -3605,7 +3605,7 @@
         "id": "dce108611cd0c5ba",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "set error message",
         "rules": [
             {
                 "t": "set",
@@ -3620,8 +3620,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1630,
-        "y": 460,
+        "x": 1870,
+        "y": 560,
         "wires": [
             [
                 "042f9d4dafa3cf3d"
@@ -3656,13 +3656,23 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1210,
-        "y": 480,
+        "x": 1390,
+        "y": 580,
         "wires": [
             [
                 "84d8b152e92556ef"
             ]
         ]
+    },
+    {
+        "id": "93e4927e83ed7795",
+        "type": "comment",
+        "z": "3ea1a4b04d852f38",
+        "name": "Images",
+        "info": "",
+        "x": 550,
+        "y": 500,
+        "wires": []
     },
     {
         "id": "dcf35b57666a30f9",

--- a/flows.json
+++ b/flows.json
@@ -2626,7 +2626,7 @@
         "upload": false,
         "swaggerDoc": "",
         "x": 130,
-        "y": 200,
+        "y": 320,
         "wires": [
             [
                 "5db8c0db8473ea8e",
@@ -2672,7 +2672,7 @@
         "repair": false,
         "outputs": 5,
         "x": 360,
-        "y": 200,
+        "y": 320,
         "wires": [
             [
                 "163b02482bbd751b"
@@ -2700,9 +2700,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "containers",
-        "x": 1110,
-        "y": 80,
+        "name": "docker api request: create container",
+        "x": 1190,
+        "y": 140,
         "wires": [
             [
                 "7b6bbc39f8d6a88e"
@@ -2722,8 +2722,8 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "networks",
-        "x": 960,
+        "name": "docker api request: create network",
+        "x": 1140,
         "y": 380,
         "wires": [
             [
@@ -2745,8 +2745,8 @@
         "winHide": false,
         "oldrc": false,
         "name": "docker api request: pull image",
-        "x": 1110,
-        "y": 580,
+        "x": 1130,
+        "y": 500,
         "wires": [
             [
                 "5c79a22a8f9ad79f"
@@ -2762,8 +2762,8 @@
         "name": "",
         "statusCode": "202",
         "headers": {},
-        "x": 130,
-        "y": 260,
+        "x": 340,
+        "y": 400,
         "wires": []
     },
     {
@@ -2813,8 +2813,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 820,
-        "y": 580,
+        "x": 840,
+        "y": 500,
         "wires": [
             [
                 "b49c4832fc35827a",
@@ -2837,8 +2837,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 580,
-        "y": 580,
+        "x": 600,
+        "y": 500,
         "wires": [
             [
                 "7d0f6463ecfeeb50"
@@ -2853,8 +2853,8 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1360,
-        "y": 660,
+        "x": 1380,
+        "y": 580,
         "wires": [
             [
                 "d375e2981f9fa4fb"
@@ -2873,8 +2873,8 @@
         "winHide": false,
         "oldrc": false,
         "name": "docker api request: inspect image",
-        "x": 1100,
-        "y": 660,
+        "x": 1120,
+        "y": 580,
         "wires": [
             [
                 "2eb2de8f9ca00a2b"
@@ -2902,8 +2902,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1840,
-        "y": 600,
+        "x": 1860,
+        "y": 520,
         "wires": [
             [
                 "cc3c1cea0eb84ca0"
@@ -2964,8 +2964,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1560,
-        "y": 660,
+        "x": 1580,
+        "y": 580,
         "wires": [
             [
                 "231e0a10bb5c0cac",
@@ -2989,8 +2989,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 1850,
-        "y": 700,
+        "x": 1870,
+        "y": 620,
         "wires": [
             [
                 "829323373ce00e9e"
@@ -3001,7 +3001,7 @@
         "id": "98985cb45ca68974",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare docker api request",
         "rules": [
             {
                 "t": "set",
@@ -3037,7 +3037,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 780,
+        "x": 860,
         "y": 380,
         "wires": [
             [
@@ -3049,7 +3049,7 @@
         "id": "060ac7e41c2e9d20",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare docker api request",
         "rules": [
             {
                 "t": "set",
@@ -3078,8 +3078,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 680,
-        "y": 300,
+        "x": 640,
+        "y": 260,
         "wires": [
             [
                 "40036eabb47532d6"
@@ -3090,7 +3090,7 @@
         "id": "ecc3d13695524e12",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare docker api request",
         "rules": [
             {
                 "t": "set",
@@ -3126,8 +3126,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 920,
-        "y": 80,
+        "x": 880,
+        "y": 140,
         "wires": [
             [
                 "12cecd82c1d9f476"
@@ -3138,24 +3138,22 @@
         "id": "163b02482bbd751b",
         "type": "switch",
         "z": "3ea1a4b04d852f38",
-        "name": "",
-        "property": "payload.data",
-        "propertyType": "msg",
+        "name": "should we create it?",
+        "property": "(\t    $boolean(msg.payload.data.name)\t    and msg.payload.data.state = \"none\"\t)",
+        "propertyType": "jsonata",
         "rules": [
             {
-                "t": "hask",
-                "v": "name",
-                "vt": "str"
+                "t": "true"
             }
         ],
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 570,
-        "y": 80,
+        "x": 620,
+        "y": 140,
         "wires": [
             [
-                "ab2c66ff78afc05b"
+                "ecc3d13695524e12"
             ]
         ]
     },
@@ -3163,7 +3161,7 @@
         "id": "836f86ac79995686",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare netbox request",
         "rules": [
             {
                 "t": "set",
@@ -3220,8 +3218,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 880,
-        "y": 220,
+        "x": 2350,
+        "y": 140,
         "wires": [
             [
                 "a363e235a4fda0b0",
@@ -3233,7 +3231,7 @@
         "id": "a363e235a4fda0b0",
         "type": "http request",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "netbox request: update container",
         "method": "use",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -3245,8 +3243,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 1070,
-        "y": 220,
+        "x": 2640,
+        "y": 140,
         "wires": [
             [
                 "14ee8c9739857e6c"
@@ -3261,8 +3259,8 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1290,
-        "y": 80,
+        "x": 1410,
+        "y": 140,
         "wires": [
             [
                 "8689e16407e06796"
@@ -3280,9 +3278,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "containers",
-        "x": 870,
-        "y": 160,
+        "name": "docker api request: inspect container",
+        "x": 1930,
+        "y": 140,
         "wires": [
             [
                 "2f564349b35d306d"
@@ -3295,7 +3293,7 @@
         "id": "8689e16407e06796",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare docker api request",
         "rules": [
             {
                 "t": "set",
@@ -3317,8 +3315,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 640,
-        "y": 160,
+        "x": 1620,
+        "y": 140,
         "wires": [
             [
                 "23ca2c7db549468c"
@@ -3333,8 +3331,8 @@
         "property": "payload",
         "action": "obj",
         "pretty": false,
-        "x": 650,
-        "y": 220,
+        "x": 2150,
+        "y": 140,
         "wires": [
             [
                 "836f86ac79995686"
@@ -3349,8 +3347,8 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1130,
-        "y": 360,
+        "x": 1350,
+        "y": 380,
         "wires": [
             [
                 "3032a954e533689f"
@@ -3361,7 +3359,7 @@
         "id": "3032a954e533689f",
         "type": "change",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "prepare netbox request",
         "rules": [
             {
                 "t": "set",
@@ -3411,8 +3409,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1140,
-        "y": 420,
+        "x": 1550,
+        "y": 380,
         "wires": [
             [
                 "01899c0865cdbdd7"
@@ -3423,7 +3421,7 @@
         "id": "01899c0865cdbdd7",
         "type": "http request",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "netbox request: update network",
         "method": "use",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -3435,36 +3433,11 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 1330,
-        "y": 420,
+        "x": 1830,
+        "y": 380,
         "wires": [
             [
                 "310b29964dbaaca6"
-            ]
-        ]
-    },
-    {
-        "id": "ab2c66ff78afc05b",
-        "type": "switch",
-        "z": "3ea1a4b04d852f38",
-        "name": "",
-        "property": "msg.payload.data.state",
-        "propertyType": "msg",
-        "rules": [
-            {
-                "t": "eq",
-                "v": "none",
-                "vt": "str"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 1,
-        "x": 730,
-        "y": 80,
-        "wires": [
-            [
-                "ecc3d13695524e12"
             ]
         ]
     },
@@ -3479,9 +3452,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "volumes",
-        "x": 880,
-        "y": 300,
+        "name": "docker api request: create volume",
+        "x": 960,
+        "y": 260,
         "wires": [
             [],
             [],
@@ -3492,7 +3465,7 @@
         "id": "1be042b22cf71230",
         "type": "switch",
         "z": "3ea1a4b04d852f38",
-        "name": "",
+        "name": "should we create it?",
         "property": "payload.data.state",
         "propertyType": "msg",
         "rules": [
@@ -3505,7 +3478,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 610,
+        "x": 620,
         "y": 380,
         "wires": [
             [
@@ -3522,8 +3495,8 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 1205,
-        "y": 220,
+        "x": 2825,
+        "y": 140,
         "wires": []
     },
     {
@@ -3535,8 +3508,8 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 1445,
-        "y": 420,
+        "x": 2005,
+        "y": 380,
         "wires": []
     },
     {
@@ -3548,8 +3521,8 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 2025,
-        "y": 700,
+        "x": 2045,
+        "y": 620,
         "wires": []
     },
     {
@@ -3557,8 +3530,8 @@
         "type": "subflow:0455d311f0e53c09",
         "z": "3ea1a4b04d852f38",
         "name": "",
-        "x": 870,
-        "y": 540,
+        "x": 890,
+        "y": 460,
         "wires": []
     },
     {
@@ -3566,8 +3539,8 @@
         "type": "subflow:0455d311f0e53c09",
         "z": "3ea1a4b04d852f38",
         "name": "",
-        "x": 2130,
-        "y": 660,
+        "x": 2150,
+        "y": 580,
         "wires": []
     },
     {
@@ -3588,8 +3561,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1610,
-        "y": 580,
+        "x": 1630,
+        "y": 500,
         "wires": [
             [
                 "dce108611cd0c5ba"
@@ -3618,8 +3591,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1870,
-        "y": 560,
+        "x": 1890,
+        "y": 480,
         "wires": [
             [
                 "042f9d4dafa3cf3d"
@@ -3631,8 +3604,8 @@
         "type": "subflow:0455d311f0e53c09",
         "z": "3ea1a4b04d852f38",
         "name": "",
-        "x": 1070,
-        "y": 260,
+        "x": 2570,
+        "y": 180,
         "wires": []
     },
     {
@@ -3654,8 +3627,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1390,
-        "y": 580,
+        "x": 1410,
+        "y": 500,
         "wires": [
             [
                 "84d8b152e92556ef"
@@ -3668,8 +3641,38 @@
         "z": "3ea1a4b04d852f38",
         "name": "Images",
         "info": "",
-        "x": 550,
-        "y": 500,
+        "x": 570,
+        "y": 460,
+        "wires": []
+    },
+    {
+        "id": "f3223f1c59aae2b0",
+        "type": "comment",
+        "z": "3ea1a4b04d852f38",
+        "name": "Networks",
+        "info": "",
+        "x": 580,
+        "y": 340,
+        "wires": []
+    },
+    {
+        "id": "a63cdf11f5086bd8",
+        "type": "comment",
+        "z": "3ea1a4b04d852f38",
+        "name": "Volumes",
+        "info": "",
+        "x": 580,
+        "y": 220,
+        "wires": []
+    },
+    {
+        "id": "6a5da2a0bc5f3b01",
+        "type": "comment",
+        "z": "3ea1a4b04d852f38",
+        "name": "Containers",
+        "info": "",
+        "x": 580,
+        "y": 100,
         "wires": []
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netbox-docker-agent",
-  "version": "0.29.4",
+  "version": "0.30.0",
   "description": "Saashup agent for netbox manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Decision Record

An image should be pulled if the request received on the endpoint `/api/engine/images` matches the following criteria:

 - the size of the image is less than, or equal to 0 (meaning, the image has not been pulled yet)
 - the field `force` is set to `true` (meaning, we want to repull the image)

## Changes

 - [x] :bulb: Give names to nodes to clarify the workflow
 - [x] :sparkles: Update condition to determine if we should pull an image or not
 - [x] :bookmark: v0.30.0