### PR TITLE
:fire: fix duplicate logs on kill

### DIFF
--- a/flows.json
+++ b/flows.json
@@ -791,8 +791,8 @@
         "method": "get",
         "upload": false,
         "swaggerDoc": "",
-        "x": 120,
-        "y": 460,
+        "x": 160,
+        "y": 220,
         "wires": [
             [
                 "53aaf7026e5a7cee",
@@ -804,7 +804,7 @@
         "id": "4f41f373f7947d21",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "route by :type",
+        "name": "",
         "property": "req.params.type",
         "propertyType": "msg",
         "rules": [
@@ -842,8 +842,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 6,
-        "x": 800,
-        "y": 500,
+        "x": 570,
+        "y": 280,
         "wires": [
             [
                 "4de06d76878cdbd0"
@@ -879,9 +879,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "docker api request: list containers",
-        "x": 1300,
-        "y": 220,
+        "name": "containers",
+        "x": 770,
+        "y": 120,
         "wires": [
             [
                 "221cb4f11aa9b1dc"
@@ -901,9 +901,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "docker api request: list volumes",
-        "x": 1290,
-        "y": 340,
+        "name": "volumes",
+        "x": 780,
+        "y": 320,
         "wires": [
             [
                 "1a50c26c9c0a0708"
@@ -923,9 +923,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "docker api request: list networks",
-        "x": 1290,
-        "y": 460,
+        "name": "networks",
+        "x": 780,
+        "y": 440,
         "wires": [
             [
                 "13f3463f42580ff9"
@@ -945,9 +945,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "docker api request: list images",
-        "x": 1290,
-        "y": 580,
+        "name": "images",
+        "x": 780,
+        "y": 560,
         "wires": [
             [
                 "bf87cac23b3411d9"
@@ -963,15 +963,15 @@
         "name": "",
         "statusCode": "202",
         "headers": {},
-        "x": 320,
-        "y": 420,
+        "x": 160,
+        "y": 280,
         "wires": []
     },
     {
         "id": "2cc40b296062191e",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare netbox request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -1007,8 +1007,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 2750,
-        "y": 600,
+        "x": 1620,
+        "y": 560,
         "wires": [
             [
                 "3cd883eb0ec5d869"
@@ -1019,7 +1019,7 @@
         "id": "1daea440d755f8c9",
         "type": "http request",
         "z": "a827fd671d6a227e",
-        "name": "netbox request: create images",
+        "name": "",
         "method": "POST",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -1031,8 +1031,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 3210,
-        "y": 600,
+        "x": 1910,
+        "y": 560,
         "wires": [
             [
                 "05457d6efadc3737"
@@ -1043,7 +1043,7 @@
         "id": "521aa77a01fcea45",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "configure netbox credentials",
+        "name": "config",
         "rules": [
             {
                 "t": "set",
@@ -1079,8 +1079,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 580,
-        "y": 420,
+        "x": 470,
+        "y": 200,
         "wires": [
             [
                 "4f41f373f7947d21"
@@ -1098,8 +1098,8 @@
         "arraySpltType": "len",
         "stream": false,
         "addname": "",
-        "x": 2570,
-        "y": 600,
+        "x": 1470,
+        "y": 560,
         "wires": [
             [
                 "2cc40b296062191e"
@@ -1110,7 +1110,7 @@
         "id": "3cd883eb0ec5d869",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "image has a name?",
+        "name": "",
         "property": "payload.name",
         "propertyType": "msg",
         "rules": [
@@ -1121,8 +1121,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 2970,
-        "y": 600,
+        "x": 1770,
+        "y": 560,
         "wires": [
             [
                 "1daea440d755f8c9"
@@ -1133,7 +1133,7 @@
         "id": "d1b84cfbb90de451",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare netbox request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -1176,7 +1176,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 2030,
+        "x": 1440,
         "y": 480,
         "wires": [
             [
@@ -1188,7 +1188,7 @@
         "id": "d262d362c08337f4",
         "type": "http request",
         "z": "a827fd671d6a227e",
-        "name": "netbox request: create networks",
+        "name": "",
         "method": "POST",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -1200,7 +1200,7 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 2290,
+        "x": 1650,
         "y": 480,
         "wires": [
             [
@@ -1216,7 +1216,7 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1490,
+        "x": 950,
         "y": 460,
         "wires": [
             [
@@ -1235,7 +1235,7 @@
         "arraySpltType": "len",
         "stream": false,
         "addname": "",
-        "x": 1850,
+        "x": 1270,
         "y": 480,
         "wires": [
             [
@@ -1247,7 +1247,7 @@
         "id": "d0800a089eab13c2",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare netbox request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -1290,8 +1290,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 2230,
-        "y": 360,
+        "x": 1060,
+        "y": 400,
         "wires": [
             [
                 "7d51fb2a4a8ebca5"
@@ -1302,7 +1302,7 @@
         "id": "7d51fb2a4a8ebca5",
         "type": "http request",
         "z": "a827fd671d6a227e",
-        "name": "netbox request: create volumes",
+        "name": "",
         "method": "POST",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -1314,8 +1314,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 2490,
-        "y": 360,
+        "x": 1270,
+        "y": 400,
         "wires": [
             [
                 "2b11dfa028894e68"
@@ -1330,8 +1330,8 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1490,
-        "y": 340,
+        "x": 930,
+        "y": 320,
         "wires": [
             [
                 "ff1efcf6edbac8aa"
@@ -1349,9 +1349,8 @@
         "arraySpltType": "len",
         "stream": false,
         "addname": "",
-        "property": "payload",
-        "x": 2050,
-        "y": 360,
+        "x": 1470,
+        "y": 340,
         "wires": [
             [
                 "d0800a089eab13c2"
@@ -1362,7 +1361,7 @@
         "id": "81887b8b8a629144",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "get volumes data",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -1377,8 +1376,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1890,
-        "y": 360,
+        "x": 1300,
+        "y": 340,
         "wires": [
             [
                 "e26b6e9ed2eaee27"
@@ -1396,9 +1395,8 @@
         "arraySpltType": "len",
         "stream": false,
         "addname": "",
-        "property": "payload",
-        "x": 1830,
-        "y": 240,
+        "x": 1270,
+        "y": 140,
         "wires": [
             [
                 "03079290b974e3ec"
@@ -1422,8 +1420,8 @@
         "drop": false,
         "allowrate": false,
         "outputs": 1,
-        "x": 1040,
-        "y": 220,
+        "x": 600,
+        "y": 120,
         "wires": [
             [
                 "df268a4a9955ef48"
@@ -1434,7 +1432,7 @@
         "id": "f4ca91fa82b0cf42",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare netbox request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -1477,7 +1475,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 2950,
+        "x": 1100,
         "y": 260,
         "wires": [
             [
@@ -1489,7 +1487,7 @@
         "id": "a02aa01b4760459f",
         "type": "http request",
         "z": "a827fd671d6a227e",
-        "name": "netbox request: create containers",
+        "name": "",
         "method": "POST",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -1501,7 +1499,7 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 3220,
+        "x": 1330,
         "y": 260,
         "wires": [
             [
@@ -1520,9 +1518,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "docker api request: inspect containers",
-        "x": 2310,
-        "y": 240,
+        "name": "containers",
+        "x": 1010,
+        "y": 200,
         "wires": [
             [
                 "42827c9888e44fd1"
@@ -1535,7 +1533,7 @@
         "id": "03079290b974e3ec",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare docker api request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -1557,8 +1555,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 2020,
-        "y": 240,
+        "x": 780,
+        "y": 200,
         "wires": [
             [
                 "417ae7536ebebf6e"
@@ -1573,8 +1571,8 @@
         "property": "payload",
         "action": "obj",
         "pretty": false,
-        "x": 2530,
-        "y": 240,
+        "x": 1170,
+        "y": 200,
         "wires": [
             [
                 "a407f99fbc5717c1"
@@ -1592,9 +1590,9 @@
         "timer": "",
         "winHide": false,
         "oldrc": false,
-        "name": "docker api request: get api version",
-        "x": 1300,
-        "y": 940,
+        "name": "version",
+        "x": 740,
+        "y": 820,
         "wires": [
             [
                 "cdf0ca856701cd23"
@@ -1614,8 +1612,8 @@
         "method": "get",
         "upload": false,
         "swaggerDoc": "",
-        "x": 1250,
-        "y": 160,
+        "x": 590,
+        "y": 60,
         "wires": [
             [
                 "df268a4a9955ef48"
@@ -1629,15 +1627,15 @@
         "name": "",
         "statusCode": "",
         "headers": {},
-        "x": 3010,
-        "y": 220,
+        "x": 1650,
+        "y": 200,
         "wires": []
     },
     {
         "id": "a407f99fbc5717c1",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "was netbox webhook?",
+        "name": "",
         "property": "req.url",
         "propertyType": "msg",
         "rules": [
@@ -1653,8 +1651,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 2700,
-        "y": 240,
+        "x": 1330,
+        "y": 200,
         "wires": [
             [
                 "deec1424f8eaa469"
@@ -1676,7 +1674,6 @@
         "key": "topic",
         "joiner": "\\n",
         "joinerType": "str",
-        "useparts": true,
         "accumulate": true,
         "timeout": "",
         "count": "",
@@ -1685,8 +1682,8 @@
         "reduceInit": "",
         "reduceInitType": "",
         "reduceFixup": "",
-        "x": 2890,
-        "y": 220,
+        "x": 1510,
+        "y": 200,
         "wires": [
             [
                 "a23553e203eafd05"
@@ -1702,8 +1699,8 @@
         "method": "get",
         "upload": false,
         "swaggerDoc": "",
-        "x": 1220,
-        "y": 880,
+        "x": 420,
+        "y": 820,
         "wires": [
             [
                 "ed796f5589c864f7"
@@ -1717,8 +1714,8 @@
         "name": "",
         "statusCode": "",
         "headers": {},
-        "x": 2010,
-        "y": 960,
+        "x": 1330,
+        "y": 820,
         "wires": []
     },
     {
@@ -1754,8 +1751,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1350,
-        "y": 880,
+        "x": 590,
+        "y": 820,
         "wires": [
             [
                 "7a4d9d8b863a0612"
@@ -1766,7 +1763,7 @@
         "id": "4acdf31cd717543f",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "is type \"endpoint\"?",
+        "name": "",
         "property": "req.params.type",
         "propertyType": "msg",
         "rules": [
@@ -1782,8 +1779,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 350,
-        "y": 500,
+        "x": 390,
+        "y": 260,
         "wires": [
             [
                 "521aa77a01fcea45"
@@ -1797,7 +1794,7 @@
         "id": "7cd37714a247d0f3",
         "type": "http request",
         "z": "a827fd671d6a227e",
-        "name": "netbox request: update host",
+        "name": "",
         "method": "use",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -1809,8 +1806,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 1540,
-        "y": 780,
+        "x": 990,
+        "y": 720,
         "wires": [
             [
                 "0f90d4602b562160"
@@ -1821,7 +1818,7 @@
         "id": "70c57a4688add144",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare netbox request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -1864,8 +1861,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1270,
-        "y": 780,
+        "x": 760,
+        "y": 720,
         "wires": [
             [
                 "7cd37714a247d0f3"
@@ -1879,15 +1876,15 @@
         "name": "",
         "statusCode": "403",
         "headers": {},
-        "x": 1720,
-        "y": 200,
+        "x": 1120,
+        "y": 60,
         "wires": []
     },
     {
         "id": "221cb4f11aa9b1dc",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "was empty?",
+        "name": "",
         "property": "payload",
         "propertyType": "msg",
         "rules": [
@@ -1901,8 +1898,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1530,
-        "y": 220,
+        "x": 950,
+        "y": 100,
         "wires": [
             [
                 "e843e090678a61b9"
@@ -1920,8 +1917,8 @@
         "property": "payload",
         "action": "obj",
         "pretty": false,
-        "x": 1710,
-        "y": 240,
+        "x": 1110,
+        "y": 120,
         "wires": [
             [
                 "eead888045896e1a"
@@ -1937,8 +1934,8 @@
         "method": "get",
         "upload": false,
         "swaggerDoc": "",
-        "x": 1240,
-        "y": 520,
+        "x": 780,
+        "y": 500,
         "wires": [
             [
                 "840619e239d214aa"
@@ -1949,7 +1946,7 @@
         "id": "0900cd90c6af5e59",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "was netbox webhook?",
+        "name": "",
         "property": "req.url",
         "propertyType": "msg",
         "rules": [
@@ -1965,8 +1962,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1650,
-        "y": 580,
+        "x": 1050,
+        "y": 560,
         "wires": [
             [
                 "39acafa9d2f2d6ba"
@@ -1983,8 +1980,8 @@
         "name": "",
         "statusCode": "",
         "headers": {},
-        "x": 1830,
-        "y": 540,
+        "x": 1190,
+        "y": 520,
         "wires": []
     },
     {
@@ -1995,8 +1992,8 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1490,
-        "y": 580,
+        "x": 930,
+        "y": 560,
         "wires": [
             [
                 "0900cd90c6af5e59"
@@ -2012,8 +2009,8 @@
         "method": "get",
         "upload": false,
         "swaggerDoc": "",
-        "x": 1250,
-        "y": 400,
+        "x": 790,
+        "y": 380,
         "wires": [
             [
                 "2efc622d38ebd4aa"
@@ -2024,7 +2021,7 @@
         "id": "6ebef0d1eb0f7066",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "was netbox webhook?",
+        "name": "",
         "property": "req.url",
         "propertyType": "msg",
         "rules": [
@@ -2040,7 +2037,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1660,
+        "x": 1090,
         "y": 460,
         "wires": [
             [
@@ -2058,7 +2055,7 @@
         "name": "",
         "statusCode": "",
         "headers": {},
-        "x": 1850,
+        "x": 1230,
         "y": 440,
         "wires": []
     },
@@ -2071,8 +2068,8 @@
         "method": "get",
         "upload": false,
         "swaggerDoc": "",
-        "x": 1240,
-        "y": 280,
+        "x": 800,
+        "y": 260,
         "wires": [
             [
                 "3c46077f2f10a641"
@@ -2083,7 +2080,7 @@
         "id": "ff1efcf6edbac8aa",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "was netbox webhook?",
+        "name": "",
         "property": "req.url",
         "propertyType": "msg",
         "rules": [
@@ -2099,8 +2096,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1660,
-        "y": 340,
+        "x": 1070,
+        "y": 320,
         "wires": [
             [
                 "8c85e65c2bfecef8"
@@ -2117,8 +2114,8 @@
         "name": "",
         "statusCode": "",
         "headers": {},
-        "x": 1850,
-        "y": 320,
+        "x": 1190,
+        "y": 300,
         "wires": []
     },
     {
@@ -2129,8 +2126,8 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1510,
-        "y": 920,
+        "x": 890,
+        "y": 820,
         "wires": [
             [
                 "f415bfcc211c0729"
@@ -2163,8 +2160,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1870,
-        "y": 940,
+        "x": 1170,
+        "y": 820,
         "wires": [
             [
                 "7581057e6d016ca9"
@@ -2175,7 +2172,7 @@
         "id": "f415bfcc211c0729",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "was netbox webhook?",
+        "name": "",
         "property": "req.url",
         "propertyType": "msg",
         "rules": [
@@ -2193,8 +2190,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1680,
-        "y": 920,
+        "x": 1030,
+        "y": 820,
         "wires": [
             [
                 "5a07511ed7c011d2"
@@ -2213,7 +2210,7 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 3395,
+        "x": 1465,
         "y": 260,
         "wires": []
     },
@@ -2226,8 +2223,8 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 2655,
-        "y": 360,
+        "x": 1415,
+        "y": 400,
         "wires": []
     },
     {
@@ -2239,7 +2236,7 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 2455,
+        "x": 1785,
         "y": 480,
         "wires": []
     },
@@ -2252,8 +2249,8 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 1695,
-        "y": 780,
+        "x": 1155,
+        "y": 720,
         "wires": []
     },
     {
@@ -2265,15 +2262,15 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 3375,
-        "y": 600,
+        "x": 2015,
+        "y": 560,
         "wires": []
     },
     {
         "id": "5a07511ed7c011d2",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare netbox request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -2330,8 +2327,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1930,
-        "y": 900,
+        "x": 1200,
+        "y": 780,
         "wires": [
             [
                 "debd21ad874ab51b"
@@ -2342,7 +2339,7 @@
         "id": "debd21ad874ab51b",
         "type": "http request",
         "z": "a827fd671d6a227e",
-        "name": "netbox request: update host",
+        "name": "",
         "method": "use",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -2354,8 +2351,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 2180,
-        "y": 900,
+        "x": 1390,
+        "y": 780,
         "wires": [
             [
                 "466a424beeab3020"
@@ -2371,15 +2368,15 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 2335,
-        "y": 900,
+        "x": 1515,
+        "y": 780,
         "wires": []
     },
     {
         "id": "53d68a4462e6d77e",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare netbox request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -2415,7 +2412,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1890,
+        "x": 1260,
         "y": 660,
         "wires": [
             [
@@ -2427,7 +2424,7 @@
         "id": "61288a7609631dc6",
         "type": "http request",
         "z": "a827fd671d6a227e",
-        "name": "netbox request: upsert registries",
+        "name": "",
         "method": "POST",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -2439,7 +2436,7 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 2150,
+        "x": 1450,
         "y": 660,
         "wires": [
             [
@@ -2451,7 +2448,7 @@
         "id": "5a72a6c552c36127",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "parse registry data",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -2473,8 +2470,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 2410,
-        "y": 600,
+        "x": 1660,
+        "y": 660,
         "wires": [
             [
                 "6faf3827d41504fd"
@@ -2485,7 +2482,7 @@
         "id": "121ec6eb7cd9d1e3",
         "type": "change",
         "z": "a827fd671d6a227e",
-        "name": "prepare netbox request",
+        "name": "",
         "rules": [
             {
                 "t": "set",
@@ -2521,8 +2518,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1890,
-        "y": 600,
+        "x": 840,
+        "y": 660,
         "wires": [
             [
                 "6a9c98bfa97f9c1e"
@@ -2533,7 +2530,7 @@
         "id": "6a9c98bfa97f9c1e",
         "type": "http request",
         "z": "a827fd671d6a227e",
-        "name": "netbox request: get registries",
+        "name": "",
         "method": "GET",
         "ret": "obj",
         "paytoqs": "ignore",
@@ -2545,8 +2542,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 2140,
-        "y": 600,
+        "x": 1050,
+        "y": 660,
         "wires": [
             [
                 "53d68a4462e6d77e"
@@ -2557,7 +2554,7 @@
         "id": "c9f9930a51ca8c8f",
         "type": "switch",
         "z": "a827fd671d6a227e",
-        "name": "failed to connect to host?",
+        "name": "",
         "property": "payload.code",
         "propertyType": "msg",
         "rules": [
@@ -2570,8 +2567,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 1570,
-        "y": 980,
+        "x": 890,
+        "y": 880,
         "wires": [
             [
                 "d3292e92a3507d2c"
@@ -2611,124 +2608,11 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1870,
-        "y": 980,
+        "x": 1070,
+        "y": 880,
         "wires": [
             [
                 "7581057e6d016ca9"
-            ]
-        ]
-    },
-    {
-        "id": "fdf2a9c83ec77858",
-        "type": "comment",
-        "z": "a827fd671d6a227e",
-        "name": "[get] /api/engine/endpoint",
-        "info": "",
-        "x": 1270,
-        "y": 720,
-        "wires": []
-    },
-    {
-        "id": "782f59368d76cbd8",
-        "type": "comment",
-        "z": "a827fd671d6a227e",
-        "name": "when `:type` is \"endpoint\", execute all routes to populate netbox",
-        "info": "",
-        "x": 650,
-        "y": 580,
-        "wires": []
-    },
-    {
-        "id": "4a209458cc75aee0",
-        "type": "http in",
-        "z": "a827fd671d6a227e",
-        "name": "",
-        "url": "/system/usage",
-        "method": "get",
-        "upload": false,
-        "swaggerDoc": "",
-        "x": 1250,
-        "y": 1040,
-        "wires": [
-            [
-                "4ebcf591c6c3e73b"
-            ]
-        ]
-    },
-    {
-        "id": "4ebcf591c6c3e73b",
-        "type": "exec",
-        "z": "a827fd671d6a227e",
-        "command": "curl -X GET --unix-socket /var/run/docker.sock http://localhost/system/df",
-        "addpay": "",
-        "append": "",
-        "useSpawn": "false",
-        "timer": "",
-        "winHide": false,
-        "oldrc": false,
-        "name": "docker api request: system df",
-        "x": 1280,
-        "y": 1100,
-        "wires": [
-            [
-                "cd85c0f71cd8a584"
-            ],
-            [],
-            []
-        ]
-    },
-    {
-        "id": "cd85c0f71cd8a584",
-        "type": "json",
-        "z": "a827fd671d6a227e",
-        "name": "",
-        "property": "payload",
-        "action": "",
-        "pretty": false,
-        "x": 1470,
-        "y": 1100,
-        "wires": [
-            [
-                "e52d4ade08206e43"
-            ]
-        ]
-    },
-    {
-        "id": "dcb8324b28bd0fcd",
-        "type": "http response",
-        "z": "a827fd671d6a227e",
-        "name": "",
-        "statusCode": "",
-        "headers": {},
-        "x": 1850,
-        "y": 1100,
-        "wires": []
-    },
-    {
-        "id": "e52d4ade08206e43",
-        "type": "change",
-        "z": "a827fd671d6a227e",
-        "name": "aggregate disk usage data",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "{\t    \"layers_size\": msg.payload.LayersSize,\t    \"images\": {\t        \"shared_size\": $reduce(\t            msg.payload.Images,\t            function($acc, $img) {\t                $acc + $img.SharedSize\t            },\t            0\t        ),\t        \"size\": $reduce(\t            msg.payload.Images,\t            function($acc, $img) {\t                $acc + $img.Size\t            },\t            0\t        ),\t        \"virtual_size\": $reduce(\t            msg.payload.Images,\t            function($acc, $img) {\t                $acc + $img.VirtualSize\t            },\t            0\t        )\t\t    },\t    \"containers\": {\t        \"size_rootfs\": $reduce(\t            msg.payload.Containers,\t            function($acc, $container) {\t                $acc + $container.SizeRootFs\t            },\t            0\t        )\t    },\t    \"volumes\": $reduce(\t        msg.payload.Volumes,\t        function($acc, $vol) {\t            $acc + $vol.UsageData.Size\t        },\t        0\t    ),\t    \"build_cache\": $reduce(\t        msg.payload.BuildCache,\t        function($acc, $cache) {\t            $acc + $cache.Size\t        },\t        0\t    )\t}",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 1660,
-        "y": 1100,
-        "wires": [
-            [
-                "dcb8324b28bd0fcd"
             ]
         ]
     },
@@ -4229,7 +4113,7 @@
                 "t": "set",
                 "p": "payload",
                 "pt": "msg",
-                "to": "{\t   \"Image\": msg.input.data.image.name & \":\" & msg.input.data.image.version,\t   \"Hostname\": msg.input.data.hostname,\t   \"Env\": [\t       $map(\t           msg.input.data.env,\t           function($v, $k) {\t               $v.var_name &\"=\" & $v.value\t            }\t        )\t    ],\t   \"Labels\": $merge(\t       $map(\t           msg.input.data.labels,\t           function($v, $k) {\t               { $v.key: $v.value }\t            }\t        )\t    ),\t   \"ExposedPorts\": $merge(\t       $map(\t           msg.input.data.ports,\t           function($v, $k) {\t               {\t                   $v.private_port & \"/\" & $v.type: {} \t                } \t            }\t        )\t    ),\t    \"NetworkingConfig\": {\t       \"EndpointsConfig\": $merge(\t           $map(\t               msg.input.data.network_settings,\t               function($v, $k) {\t                   $k = 0 ? {\t                       $v.network.name : { \"NetworkID\": $v.network.NetworkID } \t                   }\t                }\t            )\t        )\t    },\t   \"HostConfig\": {\t        \"CapAdd\": msg.input.data.cap_add,\t        \"CapDrop\": msg.input.data.cap_drop,\t        \"PidMode\": msg.input.data.pid_mode,\t        \"ExtraHosts\": msg.input.data.extra_hosts,       \t        \"PortBindings\": $merge(\t            $map(\t                msg.input.data.ports,\t                function($v, $k){\t                    {\t                        $v.private_port & \"/\" & $v.type: $v.public_port\t                        ? [\t                            {\t                                \"HostIp\": \"\",\t                                \"HostPort\" : $string($v.public_port) \t                            }\t                        ]\t                            : [] \t                    } \t                }\t            )\t        ),\t        \"Devices\": [\t            $map(\t                msg.input.data.devices,\t                function($v, $k) {\t                    {\t                        \"PathInContainer\": $v.container_path,\t                        \"PathOnHost\": $v.host_path,\t                        \"CgroupPermissions\": \"rwm\"\t                    }\t                }\t            )\t        ],\t        \"Mounts\": [\t            $map(\t                msg.input.data.mounts,\t                function($v, $k) {\t                    {\t                        \"Target\": $v.source,\t                        \"Name\": $v.volume.name,\t                        \"Type\": \"volume\",\t                        \"Destination\": $v.source,\t                        \"ReadOnly\": $v.read_only,\t                        \"Source\": $v.volume.name,\t                        \"Driver\": $v.volume.driver\t                    }\t                }\t            ),\t            $map(\t                msg.input.data.binds,\t                function($v, $k) {\t                    {\t                        \"Target\": $v.container_path,\t                        \"Type\": \"bind\",\t                        \"Destination\": $v.container_path,\t                        \"ReadOnly\": $v.read_only,\t                        \"Source\": $v.host_path,\t                        \"BindOptions\": {\t                           \"CreateMountpoint\": true\t                        }\t                    }\t               }\t            )\t        ],\t       \"RestartPolicy\": {\t           \"Name\": msg.input.data.restart_policy\t        }\t    }\t}\t",
+                "to": "{\t   \"Image\": msg.input.data.image.name & \":\" & msg.input.data.image.version,\t   \"Hostname\": msg.input.data.hostname,\t   \"Env\": [\t       $map(\t           msg.input.data.env,\t           function($v, $k) {\t               $v.var_name &\"=\" & $v.value\t            }\t        )\t    ],\t   \"Labels\": $merge(\t       $map(\t           msg.input.data.labels,\t           function($v, $k) {\t               { $v.key: $v.value }\t            }\t        )\t    ),\t   \"ExposedPorts\": $merge(\t       $map(\t           msg.input.data.ports,\t           function($v, $k) {\t               {\t                   $v.private_port & \"/\" & $v.type: {} \t                } \t            }\t        )\t    ),\t    \"NetworkingConfig\": {\t       \"EndpointsConfig\": $merge(\t           $map(\t               msg.input.data.network_settings,\t               function($v, $k) {\t                   $k = 0 ? {\t                       $v.network.name : { \"NetworkID\": $v.network.NetworkID } \t                   }\t                }\t            )\t        )\t    },\t   \"HostConfig\": {\t        \"CapAdd\": msg.input.data.cap_add,\t        \"CapDrop\": msg.input.data.cap_drop,\t        \"PidMode\": msg.input.data.pid_mode,\t        \"ExtraHosts\": msg.input.data.extra_hosts,       \t        \"PortBindings\": $merge(\t            $map(\t                msg.input.data.ports,\t                function($v, $k){\t                    {\t                        $v.private_port & \"/\" & $v.type: $v.public_port\t                        ? [\t                            {\t                                \"HostIp\": \"\",\t                                \"HostPort\" : $string($v.public_port) \t                            }\t                        ]\t                            : [] \t                    } \t                }\t            )\t        ),\t        \"Devices\": [\t            $map(\t                msg.input.data.devices,\t                function($v, $k) {\t                    {\t                        \"PathInContainer\": $v.container_path,\t                        \"PathOnHost\": $v.host_path,\t                        \"CgroupPermissions\": \"crw\"\t                    }\t                }\t            )\t        ],\t        \"Mounts\": [\t            $map(\t                msg.input.data.mounts,\t                function($v, $k) {\t                    {\t                        \"Target\": $v.source,\t                        \"Name\": $v.volume.name,\t                        \"Type\": \"volume\",\t                        \"Destination\": $v.source,\t                        \"ReadOnly\": $v.read_only,\t                        \"Source\": $v.volume.name,\t                        \"Driver\": $v.volume.driver\t                    }\t                }\t            ),\t            $map(\t                msg.input.data.binds,\t                function($v, $k) {\t                    {\t                        \"Target\": $v.container_path,\t                        \"Type\": \"bind\",\t                        \"Destination\": $v.container_path,\t                        \"ReadOnly\": $v.read_only,\t                        \"Source\": $v.host_path,\t                        \"BindOptions\": {\t                           \"CreateMountpoint\": true\t                        }\t                    }\t               }\t            )\t        ],\t       \"RestartPolicy\": {\t           \"Name\": msg.input.data.restart_policy\t        }\t    }\t}\t",
                 "tot": "jsonata"
             },
             {
@@ -4245,6 +4129,13 @@
                 "pt": "msg",
                 "to": "input.data.ContainerID",
                 "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "journal",
+                "pt": "msg",
+                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"success\",\t   \"comments\": \"operation \" & msg.input.data.operation & \": ok\"\t}",
+                "tot": "jsonata"
             }
         ],
         "action": "",
@@ -4640,13 +4531,6 @@
                 "pt": "msg",
                 "to": "[{\t    \"id\": msg.input.data.id,\t    \"host\": msg.input.data.host.id,\t    \"name\": $replace(msg.result.Name,\"/\",\"\"),\t    \"hostname\": msg.result.Config.Hostname,\t    \"operation\": \"none\",\t    \"state\": msg.result.State.Status,\t    \"status\": msg.result.State.Status = \"running\"\t        ? \"running \" & $ceil(($toMillis($now()) - $toMillis(msg.result.State.StartedAt)) / 1000 / 60 / 60 / 24) & \"d\"\t        : \"na\",\t    \"image\": {\t        \"host\": msg.input.data.host.id,\t        \"ImageID\": msg.result.Image\t    },\t    \"ContainerID\": msg.result.Id,\t    \"network_settings\": [\t        $each(\t            msg.result.NetworkSettings.Networks,\t            function($v, $k) {\t                { \"network\": { \"name\": $k, \"host\": msg.config.id } }\t            }\t        )\t    ],\t    \"ports\": msg.result.NetworkSettings.Ports\t        ? [\t            $each(\t                msg.result.NetworkSettings.Ports,\t                function($v, $k) {\t                    {\t                        \"public_port\": $v[0] = null ? 0 : $v[0].HostPort,\t                        \"private_port\": $split($k,\"/\")[0],\t                        \"type\": $split($k,\"/\")[1]\t                    }\t                }\t            )\t          ]\t        : [\t            $each(\t                msg.result.Config.ExposedPorts,\t                function($v, $k) {\t                    $not($exists($lookup($v,'IP'))) or $lookup($v,'IP') = \"0.0.0.0\"\t                        ? {\t                            \"public_port\": $v.PublicPort ? $v.PublicPort : \"0\",\t                            \"private_port\": $split($k,\"/\")[0],\t                            \"type\": $split($k,\"/\")[1]\t                        }\t                    }\t                )\t          ],\t    \"env\": [\t        $map(\t            msg.result.Config.Env,\t            function($v, $k) {\t                {\t                    \"var_name\": $substringBefore($v, \"=\"),\t                    \"value\": $substringAfter($v, \"=\")\t                }\t            }\t        )\t    ],\t    \"labels\": [\t        $each(\t            msg.result.Config.Labels,\t            function($v, $k) {\t                { \"key\": $k, \"value\": $v }\t            }\t        )\t    ],\t    \"mounts\": [\t        $map(\t            msg.result.Mounts,\t            function($v, $k) {\t                $v.Type = \"volume\"\t                    ? {\t                        \"source\": $v.Destination,\t                        \"volume\": { \"name\": $v.Name, \"host\": msg.config.id },\t                        \"read_only\": $not($v.RW)\t                    }\t            }\t        )\t    ],\t    \"binds\": [\t        $map(\t            msg.result.Mounts,\t            function($v, $k) {\t                $v.Type = \"bind\"\t                    ? {\t                        \"host_path\": $v.Source,\t                        \"container_path\": $v.Destination,\t                        \"read_only\": $not($v.RW)\t                    }\t            }\t        )\t    ]\t}]",
                 "tot": "jsonata"
-            },
-            {
-                "t": "set",
-                "p": "journal",
-                "pt": "msg",
-                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"success\",\t   \"comments\": \"operation \" & msg.input.data.operation & \": ok\"\t}",
-                "tot": "jsonata"
             }
         ],
         "action": "",
@@ -4678,8 +4562,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 1130,
-        "y": 760,
+        "x": 1270,
+        "y": 740,
         "wires": [
             [
                 "d10c0e59950649aa"
@@ -4695,8 +4579,8 @@
         "links": [
             "a12cfbe9ec7b317a"
         ],
-        "x": 1585,
-        "y": 240,
+        "x": 1665,
+        "y": 280,
         "wires": []
     },
     {
@@ -4716,8 +4600,8 @@
         "drop": false,
         "allowrate": false,
         "outputs": 1,
-        "x": 1460,
-        "y": 240,
+        "x": 1540,
+        "y": 280,
         "wires": [
             [
                 "ec4a365091d27e97"
@@ -4758,8 +4642,8 @@
         "links": [
             "36f439d2ba0ac71a"
         ],
-        "x": 1265,
-        "y": 760,
+        "x": 1415,
+        "y": 740,
         "wires": []
     },
     {
@@ -4780,34 +4664,24 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1130,
+        "x": 1150,
         "y": 300,
         "wires": [
             [
-                "29132a5a3f72e359"
+                "6112bc9fc462739a"
             ],
             [
-                "2ca8bc5af87333b2",
-                "29132a5a3f72e359"
+                "fd627a14335caef4"
             ]
         ]
-    },
-    {
-        "id": "803bd832af0f5029",
-        "type": "subflow:0455d311f0e53c09",
-        "z": "8e85e8c54d776ddc",
-        "name": "",
-        "x": 1670,
-        "y": 300,
-        "wires": []
     },
     {
         "id": "f97a2faad0f4275a",
         "type": "subflow:0455d311f0e53c09",
         "z": "8e85e8c54d776ddc",
         "name": "",
-        "x": 1130,
-        "y": 820,
+        "x": 1250,
+        "y": 800,
         "wires": []
     },
     {
@@ -4829,11 +4703,11 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1500,
-        "y": 300,
+        "x": 1380,
+        "y": 320,
         "wires": [
             [
-                "803bd832af0f5029"
+                "29132a5a3f72e359"
             ]
         ]
     },
@@ -5285,39 +5159,12 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 930,
-        "y": 820,
+        "x": 1050,
+        "y": 760,
         "wires": [
             [
                 "f97a2faad0f4275a",
                 "c469b4b880927dc6"
-            ],
-            []
-        ]
-    },
-    {
-        "id": "2ca8bc5af87333b2",
-        "type": "switch",
-        "z": "8e85e8c54d776ddc",
-        "name": "",
-        "property": "config.id",
-        "propertyType": "global",
-        "rules": [
-            {
-                "t": "nempty"
-            },
-            {
-                "t": "else"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 2,
-        "x": 1330,
-        "y": 300,
-        "wires": [
-            [
-                "fd627a14335caef4"
             ],
             []
         ]
@@ -5476,6 +5323,33 @@
         "x": 455,
         "y": 440,
         "wires": []
+    },
+    {
+        "id": "6112bc9fc462739a",
+        "type": "change",
+        "z": "8e85e8c54d776ddc",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{\t   \"assigned_object_type\": \"netbox_docker_plugin.container\",\t   \"assigned_object_id\": msg.input.data.id,\t   \"kind\": \"success\",\t   \"comments\": \"operation \" & msg.input.data.operation & \": ok\"\t}",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 1360,
+        "y": 280,
+        "wires": [
+            [
+                "29132a5a3f72e359"
+            ]
+        ]
     },
     {
         "id": "3eb97ccb653722a0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netbox-docker-agent",
-  "version": "0.31.3",
+  "version": "0.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netbox-docker-agent",
-      "version": "0.31.3",
+      "version": "0.32.1",
       "license": "ISC",
       "dependencies": {
         "node-red": "*"
@@ -1894,9 +1894,9 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netbox-docker-agent",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Saashup agent for netbox manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
after the implementation of the kill feature in the netbox plugin it has beend discovered we send duplicated logs for a kill command.
we have the info and then we get both success and failed logs.

This PR is to fix that behaviour.