### PR TITLE
:adhesive_bandage: handle bulk image delete by rate limiting the registry update

### DIFF
--- a/flows.json
+++ b/flows.json
@@ -7622,8 +7622,8 @@
         "y": 300,
         "wires": [
             [
-                "06d9e416e24ea04b",
-                "b87eba8ac3329ce3"
+                "b87eba8ac3329ce3",
+                "85496ede05318bc8"
             ],
             [],
             []
@@ -8117,7 +8117,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1760,
+        "x": 1970,
         "y": 300,
         "wires": [
             []
@@ -8143,6 +8143,31 @@
         "wires": [
             [
                 "74282c37e59eb461"
+            ]
+        ]
+    },
+    {
+        "id": "85496ede05318bc8",
+        "type": "delay",
+        "z": "177047e3d7a351be",
+        "name": "",
+        "pauseType": "rate",
+        "timeout": "5",
+        "timeoutUnits": "seconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 1750,
+        "y": 300,
+        "wires": [
+            [
+                "06d9e416e24ea04b"
             ]
         ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netbox-docker-agent",
-  "version": "1.12.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netbox-docker-agent",
-      "version": "1.12.0",
+      "version": "1.13.1",
       "license": "ISC",
       "dependencies": {
         "docker-exec-websocket-server": "^1.3.7",
@@ -17,13 +17,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2802,9 +2799,9 @@
       }
     },
     "node_modules/mqtt/node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3665,12 +3662,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/reinterval": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netbox-docker-agent",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Saashup agent for netbox manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When we bulk delete image the registry may not have the right configuration as per the concurrency of the request.

This PR will add a rate limit and buffering of the registry update.